### PR TITLE
Fix #11: Fix the case where Package and Project name are the same.

### DIFF
--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -216,7 +216,9 @@ function find_tests_in_file!(jw, uri, cst, fallback_project_uri)
         package_name = jw._packages[package_uri].name
     end
 
-    if haskey(jw._projects, project_uri)
+    if project_uri == package_uri
+        # nothing to do
+    elseif haskey(jw._projects, project_uri)
         relevant_project = jw._projects[project_uri]
 
         if !haskey(relevant_project.deved_packages, package_uri)


### PR DESCRIPTION
This is the case where the user has opened a package directory and wants to run the test for that package.

Fixes #11.

@davidanthoff: It was way easier to fix this case than to add a test case. I was struggling to write a unit test, and I couldn't figure out how to do an integration test, since it seems like this is mostly driven through VSCode?

Do you have any recommendations? Or would you just leave this untested for now?
